### PR TITLE
Add functionality to support async_scope::spawn_on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ endfunction()
 
 def_example(example.hello_world "examples/hello_world.cpp")
 def_example(example.hello_coro "examples/hello_coro.cpp")
+def_example(example.scope "examples/scope.cpp")
 def_example(example.retry "examples/retry.cpp")
 def_example(example.then "examples/then.cpp")
 def_example(example.server_theme.let_value "examples/server_theme/let_value.cpp")

--- a/examples/scope.cpp
+++ b/examples/scope.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pull in the reference implementation of P2300:
+#include <execution.hpp>
+
+#include "./schedulers/static_thread_pool.hpp"
+
+#include <cstdio>
+
+///////////////////////////////////////////////////////////////////////////////
+// Example code:
+using namespace std::execution;
+using std::this_thread::sync_wait;
+
+int main() {
+  example::static_thread_pool ctx{1};
+  async_scope scope;
+
+  scheduler auto sch = ctx.get_scheduler();                               // 1
+
+  sender auto begin = schedule(sch);                                      // 2
+
+  sender auto printVoid = then(begin, 
+    []()noexcept { printf("void\n"); });                                  // 3
+
+  sender auto printEmpty = then(on(sch, scope.empty()), 
+    []()noexcept{ printf("scope is empty\n"); });                         // 4
+
+
+  printf("\n"
+    "spawn void\n"
+    "==========\n");
+
+  scope.spawn(printVoid);                                                 // 5
+
+  sync_wait(printEmpty);
+
+
+  printf("\n"
+    "spawn void and 42\n"
+    "=================\n");
+
+  sender auto fortyTwo = then(begin, []()noexcept {return 42;});          // 6
+
+  scope.spawn(printVoid);                                                 // 7
+
+  sender auto fortyTwoFuture = scope.spawn_future(fortyTwo);              // 8
+
+  sender auto printFortyTwo = then(std::move(fortyTwoFuture), 
+    [](int fortyTwo)noexcept{ printf("%d\n", fortyTwo); });               // 9
+
+  sender auto allDone = then(
+    when_all(printEmpty, std::move(printFortyTwo)), 
+    [](auto&&...)noexcept{printf("\nall done\n");});                      // 10
+
+  sync_wait(std::move(allDone));
+}

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2030,17 +2030,6 @@ namespace std::execution {
 
         [[no_unique_address]] _Fun __fun_;
 
-        template <receiver _Receiver>
-          requires __invocable_with_values_from<_Fun, _Sender, env_of_t<_Receiver>> &&
-            sender_to<_Sender, __receiver<_Receiver>>
-        auto connect(_Receiver&& __rcvr) const&
-          noexcept(__has_nothrow_connect<_Sender, __receiver<_Receiver>>)
-          -> connect_result_t<_Sender, __receiver<_Receiver>> {
-          return execution::connect(
-              this->base(),
-              __receiver<_Receiver>{(_Receiver&&) __rcvr, __fun_});
-        }
-
         template <class... _Args>
             requires invocable<_Fun, _Args...>
           using __set_value =
@@ -2062,6 +2051,16 @@ namespace std::execution {
           return execution::connect(
               ((__sender&&) *this).base(),
               __receiver<_Receiver>{(_Receiver&&) __rcvr, (_Fun&&) __fun_});
+        }
+
+        template <class _Receiver>
+          requires sender_to<_Sender, __receiver<_Receiver>>
+        auto connect(_Receiver&& __rcvr) const&
+          noexcept(__has_nothrow_connect<_Sender, __receiver<_Receiver>>)
+          -> connect_result_t<_Sender, __receiver<_Receiver>> {
+          return execution::connect(
+              this->base(),
+              __receiver<_Receiver>{(_Receiver&&) __rcvr, __fun_});
         }
 
         template <class _Env>
@@ -3109,7 +3108,9 @@ struct __sender {
     : evt_(&evt) {}
 
   template <__decays_to<__sender> _Self, receiver _Receiver>
-    requires receiver_of<_Receiver> && __scheduler_provider<env_of_t<_Receiver>>
+    requires environment_provider<_Receiver> && 
+    receiver_of<_Receiver, completion_signatures_of_t<_Self, env_of_t<_Receiver>>> && 
+    __scheduler_provider<env_of_t<_Receiver>>
   friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
       -> operation<remove_cvref_t<_Receiver>> {
     return operation<remove_cvref_t<_Receiver>>{*__self.evt_, (_Receiver&&)__rcvr};
@@ -3202,11 +3203,11 @@ class __receiver
   : private receiver_adaptor<__receiver<_Receiver>, _Receiver> {
   friend receiver_adaptor<__receiver<_Receiver>, _Receiver>;
 
-  auto get_env(const __receiver& __self)
+  auto get_env() const&
     -> make_env_t<get_stop_token_t, never_stop_token, env_of_t<_Receiver>> {
     return make_env<get_stop_token_t>(
       never_stop_token{},
-      execution::get_env(__self.base()));
+      execution::get_env(this->base()));
   }
 
   public:
@@ -3446,10 +3447,12 @@ namespace __scope {
 
     template <class _Sender2 = _Sender, class... _As>
       requires constructible_from<__impl::__future_result_t<_Sender2>, _As...>
-    void set_value(_As&&... __as) {
+    void set_value(_As&&... __as) noexcept try {
       auto& state = *reinterpret_cast<__future_state<_Sender>*>(op_);
       state.__data_.template emplace<1>((_As&&) __as...);
       dispatch_result();
+    } catch(...) {
+      std::terminate();
     }
     [[noreturn]] void set_error(std::exception_ptr) noexcept {
       std::terminate();

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -12,6 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Some functions (as marked) derived from libunifex, (c) Facebook,
+ * in accordance with the terms of the Apache License Version 2.0,
+ * the full text of which is available at https://llvm.org/LICENSE.txt
  */
 #pragma once
 
@@ -670,37 +674,6 @@ namespace std::execution {
   // NOT TO SPEC
   template <scheduler _Scheduler>
     using schedule_result_t = __call_result_t<schedule_t, _Scheduler>;
-
-#if 0
-namespace _on {
-  inline const struct _fn {
-    template<typename Scheduler, typename Sender>
-        requires sender<Sender> && scheduler<Scheduler> &&
-          tag_invocable<_fn, Sender, Scheduler>
-    auto operator()(Scheduler&& scheduler, Sender&& sender) const
-      noexcept/*(is_nothrow_tag_invocable_v<_fn, Scheduler, Sender>)*/
-        -> tag_invoke_result_t<_fn, Scheduler, Sender> {
-      return tag_invoke(
-          _fn{}, (Scheduler &&) scheduler, (Sender &&) sender);
-    }
-
-    template<typename Scheduler, typename Sender>
-    requires sender<Sender> && scheduler<Scheduler> &&
-          (!tag_invocable<_fn, Scheduler, Sender>)
-    auto operator()(Scheduler&& scheduler, Sender&& sender) const {
-      auto scheduleSender = schedule(scheduler);
-      return sequence(
-        std::move(scheduleSender),
-        with_query_value(
-          (Sender&&) sender,
-          get_scheduler,
-          (Scheduler&&) scheduler));
-    }
-  } on{};
-} // namespace _on
-
-using _on::on;
-#endif
 
 
   /////////////////////////////////////////////////////////////////////////////
@@ -2142,6 +2115,7 @@ using _on::on;
   inline constexpr then_t then{};
 
 
+  // Derived from libunifex include/unifex/just_from.hpp
   namespace _just_from {
     inline const struct _fn {
       template <typename Callable>
@@ -3842,6 +3816,8 @@ namespace __scope {
       }
     }
 
+    // Derived from async_scope::spawn_on from
+    // libunifex include/unifex/async_scope.hpp
     template <typename Sender, typename Scheduler>
     //    requires scheduler<Scheduler> &&
     //    sender_to<
@@ -3899,6 +3875,8 @@ namespace __scope {
       return stopSource_.request_stop();
     }
 
+    // Derived from async_scope::complete from
+    // libunifex include/unifex/async_scope.hpp
     auto complete() noexcept {
         just_from([this] () noexcept {
           end_of_scope();

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -750,6 +750,12 @@ namespace std::execution {
     using stop_token_of_t =
       remove_cvref_t<decltype(get_stop_token(__declval<_T>()))>;
 
+  template <class _SchedulerProvider>
+    concept __scheduler_provider =
+      requires (const _SchedulerProvider& __sp) {
+        { get_scheduler(__sp) } -> scheduler<>;
+      };
+
   /////////////////////////////////////////////////////////////////////////////
   // [execution.op_state]
   namespace __start {
@@ -1845,7 +1851,6 @@ namespace std::execution {
             execution::set_stopped(__get_base((_Derived&&) __self));
           }
 
-          // Pass through the get_env receiver query
           template <class _D = _Derived>
             requires __has_get_env<_D>
           friend auto tag_invoke(get_env_t, const _Derived& __self) {
@@ -2024,6 +2029,17 @@ namespace std::execution {
           using __receiver = __receiver<__x<remove_cvref_t<_Receiver>>, _Fun>;
 
         [[no_unique_address]] _Fun __fun_;
+
+        template <receiver _Receiver>
+          requires __invocable_with_values_from<_Fun, _Sender, env_of_t<_Receiver>> &&
+            sender_to<_Sender, __receiver<_Receiver>>
+        auto connect(_Receiver&& __rcvr) const&
+          noexcept(__has_nothrow_connect<_Sender, __receiver<_Receiver>>)
+          -> connect_result_t<_Sender, __receiver<_Receiver>> {
+          return execution::connect(
+              this->base(),
+              __receiver<_Receiver>{(_Receiver&&) __rcvr, __fun_});
+        }
 
         template <class... _Args>
             requires invocable<_Fun, _Args...>
@@ -3003,7 +3019,6 @@ namespace std::execution {
 
         run_loop* __loop_;
       };
-
       __scheduler get_scheduler() {
         return __scheduler{this};
       }
@@ -3073,6 +3088,647 @@ namespace std::execution {
 
   // NOT TO SPEC
   using run_loop = __loop::run_loop;
+
+namespace __event {
+
+struct _op_base;
+
+template <typename Receiver>
+struct _operation {
+  struct type;
+};
+
+template <typename Receiver>
+using operation = typename _operation<Receiver>::type;
+
+struct async_manual_reset_event;
+
+struct __sender {
+
+  explicit __sender(const async_manual_reset_event& evt) noexcept
+    : evt_(&evt) {}
+
+  template <__decays_to<__sender> _Self, receiver _Receiver>
+    requires receiver_of<_Receiver> && __scheduler_provider<env_of_t<_Receiver>>
+  friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
+      -> operation<remove_cvref_t<_Receiver>> {
+    return operation<remove_cvref_t<_Receiver>>{*__self.evt_, (_Receiver&&)__rcvr};
+  }
+
+  template <__decays_to<__sender> _Self, class _Env>
+    friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
+      -> std::execution::completion_signatures<
+        std::execution::set_value_t(), 
+        std::execution::set_error_t(std::exception_ptr)>;
+
+ private:
+  const async_manual_reset_event* evt_;
+};
+
+struct async_manual_reset_event {
+  async_manual_reset_event() noexcept
+    : async_manual_reset_event(false) {}
+
+  explicit async_manual_reset_event(bool startSignalled) noexcept
+    : state_(startSignalled ? this : nullptr) {}
+
+  void set() noexcept;
+
+  bool ready() const noexcept {
+    return state_.load(std::memory_order_acquire) ==
+        static_cast<const void*>(this);
+  }
+
+  void reset() noexcept {
+    // transition from signalled (i.e. state_ == this) to not-signalled
+    // (i.e. state_ == nullptr).
+    void* oldState = this;
+
+    // We can ignore the the result.  We're using _strong so it won't fail
+    // spuriously; if it fails, it means it wasn't previously in the signalled
+    // state so resetting is a no-op.
+    (void)state_.compare_exchange_strong(
+        oldState, nullptr, std::memory_order_acq_rel);
+  }
+
+  [[nodiscard]] __sender async_wait() const noexcept {
+    return __sender{*this};
+  }
+
+ private:
+  std::atomic<void*> state_{};
+
+  friend struct _op_base;
+
+  // note: this is a static method that takes evt *second* because the caller
+  //       a member function on _op_base and so will already have op in first
+  //       argument position; making this function a member would require some
+  //       register-juggling code, which would increase binary size
+  static void start_or_wait(_op_base& op, const async_manual_reset_event& evt) noexcept;
+};
+
+struct _op_base {
+  // note: next_ is intentionally left indeterminate until the operation is
+  //       pushed on the event's stack of waiting operations
+  //
+  // note: next_ and setValue_ are the first two members because this ordering
+  //       leads to smaller code than others; on ARM, the first two members can
+  //       be loaded into a pair of registers in one instruction, which turns
+  //       out to be important in both async_manual_reset_event::set() and
+  //       start_or_wait().
+  _op_base* next_;
+  void (*setValue_)(_op_base*) noexcept;
+  const async_manual_reset_event* evt_;
+
+  explicit _op_base(const async_manual_reset_event& evt, void (*setValue)(_op_base*) noexcept) noexcept
+    : setValue_(setValue), evt_(&evt) {}
+
+  ~_op_base() = default;
+
+  _op_base(_op_base&&) = delete;
+  _op_base& operator=(_op_base&&) = delete;
+
+  void set_value() noexcept {
+    setValue_(this);
+  }
+
+  void start() noexcept {
+    async_manual_reset_event::start_or_wait(*this, *evt_);
+  }
+};
+
+template <class _Receiver>
+class __receiver
+  : private receiver_adaptor<__receiver<_Receiver>, _Receiver> {
+  friend receiver_adaptor<__receiver<_Receiver>, _Receiver>;
+
+  auto get_env(const __receiver& __self)
+    -> make_env_t<get_stop_token_t, never_stop_token, env_of_t<_Receiver>> {
+    return make_env<get_stop_token_t>(
+      never_stop_token{},
+      execution::get_env(__self.base()));
+  }
+
+  public:
+  using receiver_adaptor<__receiver, _Receiver>::receiver_adaptor;
+};
+
+template <typename Receiver>
+auto connect_as_unstoppable(Receiver&& r) noexcept(
+    __has_nothrow_connect<
+        decltype(schedule(get_scheduler(get_env(r))), get_stop_token, never_stop_token{}),
+        __receiver<Receiver>>) {
+  return connect(
+      schedule(get_scheduler(get_env(r))),
+      __receiver<Receiver>{std::move(r)});
+}
+
+template <typename Receiver>
+struct _operation<Receiver>::type : private _op_base {
+  explicit type(const async_manual_reset_event& evt, Receiver r)
+      noexcept(noexcept(connect_as_unstoppable(std::move(r))))
+    : _op_base(evt, &set_value_impl),
+      op_(connect_as_unstoppable(std::move(r))) {}
+
+  ~type() = default;
+
+  type(type&&) = delete;
+  type& operator=(type&&) = delete;
+
+ private:
+  friend void tag_invoke(start_t, type& self) noexcept {
+    self.start();
+  }
+
+  [[no_unique_address]] decltype(connect_as_unstoppable(std::declval<Receiver>())) op_;
+
+  static void set_value_impl(_op_base* base) noexcept {
+    auto self = static_cast<type*>(base);
+    std::execution::start(self->op_);
+  }
+};
+
+inline void async_manual_reset_event::set() noexcept {
+  void* const signalledState = this;
+
+  // replace the stack of waiting operations with a sentinel indicating we've
+  // been signalled
+  void* top = state_.exchange(signalledState, std::memory_order_acq_rel);
+
+  if (top == signalledState) {
+    // we were already signalled so there are no waiting operations
+    return;
+  }
+
+  // We are the first thread to set the state to signalled; iteratively pop
+  // the stack and complete each operation.
+  auto op = static_cast<_op_base*>(top);
+  while (op != nullptr) {
+    std::exchange(op, op->next_)->set_value();
+  }
+}
+
+inline void async_manual_reset_event::start_or_wait(_op_base& op, const async_manual_reset_event& evt) noexcept {
+  async_manual_reset_event& e = const_cast<async_manual_reset_event&>(evt);
+  // Try to push op onto the stack of waiting ops.
+  void* const signalledState = &e;
+
+  void* top = e.state_.load(std::memory_order_acquire);
+
+  do {
+    if (top == signalledState) {
+      // Already in the signalled state; don't push it.
+      op.set_value();
+      return;
+    }
+
+    // note: on the first iteration, this line transitions op.next_ from
+    //       indeterminate to a well-defined value
+    op.next_ = static_cast<_op_base*>(top);
+  } while (!e.state_.compare_exchange_weak(
+      top,
+      static_cast<void*>(&op),
+      std::memory_order_release,
+      std::memory_order_acquire));
+}
+
+} // namespace __event
+
+using __event::async_manual_reset_event;
+
+namespace __scope {
+
+  struct async_scope;
+
+  struct _receiver_base {
+    void* op_;
+    async_scope* scope_;
+  };
+
+  template <typename _Sender>
+  struct __receiver {
+    struct type;
+  };
+
+  template <typename _Sender>
+  using receiver = typename __receiver<_Sender>::type;
+
+  template <typename _Sender>
+  using _operation_t = connect_result_t<_Sender, receiver<_Sender>>;
+
+  template <typename _Sender>
+  struct __future_receiver {
+    struct type;
+  };
+
+  template <typename _Sender>
+  using future_receiver = typename __future_receiver<_Sender>::type;
+
+  template <typename _Sender>
+  using _future_operation_t = connect_result_t<_Sender, future_receiver<_Sender>>;
+
+  void record_done(async_scope*) noexcept;
+
+  template <typename Sender>
+  struct __receiver<Sender>::type final : private receiver_adaptor<receiver<Sender>>, _receiver_base {
+
+    template <typename Op>
+    explicit type(Op* op, async_scope* scope) noexcept
+      : receiver_adaptor<receiver<Sender>>{}, _receiver_base{op, scope} {
+      static_assert(same_as<Op, std::optional<_operation_t<Sender>>>);
+    }
+
+    // receivers uniquely own themselves; we don't need any special move-
+    // construction behaviour, but we do need to ensure no copies are made
+    type(type&&) noexcept = default;
+
+    ~type() = default;
+
+    // it's just simpler to skip this
+    type& operator=(type&&) = delete;
+
+  private:
+    friend receiver_adaptor<receiver<Sender>>;
+
+    void set_value() noexcept {
+      set_stopped();
+    }
+
+    [[noreturn]] void set_error(std::exception_ptr) noexcept {
+      std::terminate();
+    }
+
+    void set_stopped() noexcept {
+      // we're about to delete this, so save the scope for later
+      auto scope = scope_;
+      auto op = static_cast<std::optional<_operation_t<Sender>>*>(op_);
+      delete op;
+      record_done(scope);
+    }
+
+    make_env_t<get_stop_token_t, never_stop_token> get_env() const& {
+      return make_env<get_stop_token_t>(never_stop_token{});
+    }
+  };
+
+  template<sender _Sender>
+  class __future_state;
+
+  namespace __impl {
+    struct __subscription {
+      virtual void __complete_() noexcept = 0;
+      __subscription* __next_ = nullptr;
+    };
+
+    template <typename _SenderId, typename _ReceiverId>
+      class __operation final : __subscription {
+        using _Sender = __t<_SenderId>;
+        using _Receiver = __t<_ReceiverId>;
+
+        friend void tag_invoke(start_t, __operation& __op_state) noexcept {
+          __op_state.__start_();
+        }
+
+        void __complete_() noexcept override try {
+          static_assert(sender_to<_Sender, _Receiver>);
+          if (__state_->__data_.index() == 2 || get_stop_token(get_env(__rcvr_)).stop_requested()) {
+            set_stopped((_Receiver&&) __rcvr_);
+          } else if (__state_->__data_.index() == 1) {
+            std::apply([this](auto&&... as) { set_value((_Receiver&&) __rcvr_, ((decltype(as)&&)as)...); }, std::move(std::get<1>(__state_->__data_)));
+          } else {
+            std::terminate();
+          }
+        } catch(...) {
+          set_error((_Receiver&&) __rcvr_, current_exception());
+        }
+
+        void __start_() noexcept;
+
+        [[no_unique_address]] _Receiver __rcvr_;
+        std::unique_ptr<__future_state<_Sender>> __state_;
+
+        public:
+        template <typename _Receiver2>
+        explicit __operation(_Receiver2&& __rcvr, std::unique_ptr<__future_state<_Sender>> __state)
+          : __rcvr_((_Receiver2 &&) __rcvr)
+          , __state_(std::move(__state)) {}
+      };
+
+    template<sender _Sender>
+    using __future_result_t =
+      execution::value_types_of_t<
+        _Sender,
+        __empty_env,
+        execution::__decayed_tuple,
+        __single_t>;
+  } // namespace __impl
+
+  template <typename _Sender>
+  struct __future_receiver<_Sender>::type final : private receiver_adaptor<future_receiver<_Sender>>, _receiver_base {
+
+    template <typename State>
+    explicit type(State* state, async_scope* scope) noexcept
+      : receiver_adaptor<future_receiver<_Sender>>{}, _receiver_base{state, scope} {
+      static_assert(same_as<State, __future_state<_Sender>>);
+    }
+
+    // receivers uniquely own themselves; we don't need any special move-
+    // construction behaviour, but we do need to ensure no copies are made
+    type(type&&) noexcept = default;
+
+    ~type() = default;
+
+    // it's just simpler to skip this
+    type& operator=(type&&) = delete;
+
+  private:
+    friend receiver_adaptor<future_receiver<_Sender>>;
+
+    template <class _Sender2 = _Sender, class... _As>
+      requires constructible_from<__impl::__future_result_t<_Sender2>, _As...>
+    void set_value(_As&&... __as) {
+      auto& state = *reinterpret_cast<__future_state<_Sender>*>(op_);
+      state.__data_.template emplace<1>((_As&&) __as...);
+      dispatch_result();
+    }
+    [[noreturn]] void set_error(std::exception_ptr) noexcept {
+      std::terminate();
+    }
+    void set_stopped() noexcept {
+      auto& state = *reinterpret_cast<__future_state<_Sender>*>(op_);
+      state.__data_.template emplace<2>(execution::set_stopped);
+      dispatch_result();
+    }
+
+    void dispatch_result() {
+      auto& state = *reinterpret_cast<__future_state<_Sender>*>(op_);
+      while(auto* __sub = state.__pop_front_()) {
+        __sub->__complete_();
+      }
+      record_done(scope_);
+    }
+
+    make_env_t<get_stop_token_t, never_stop_token> get_env() const& {
+      return make_env<get_stop_token_t>(never_stop_token{});
+    }
+  };
+
+  template<sender _Sender>
+  class __future;
+
+  template<sender _Sender>
+  class __future_state : std::enable_shared_from_this<__future_state<_Sender>> {
+    template <class, class>
+      friend class __impl::__operation;
+    template <class>
+      friend struct __future_receiver;
+    template <sender>
+      friend class __future;
+    friend struct async_scope;
+
+
+    using op_t = _future_operation_t<_Sender>;
+
+    std::optional<op_t> __op_;
+    variant<monostate, __impl::__future_result_t<_Sender>, execution::set_stopped_t> __data_;
+
+    void __push_back_(__impl::__subscription* __task);
+    __impl::__subscription* __pop_front_();
+
+    mutex __mutex_;
+    condition_variable __cv_;
+    __impl::__subscription* __head_ = nullptr;
+    __impl::__subscription* __tail_ = nullptr;
+  };
+
+  namespace __impl {
+    template <typename _SenderId, typename _ReceiverId>
+    inline void __operation<_SenderId, _ReceiverId>::__start_() noexcept try {
+      if (!!__state_) {
+        if (__state_->__data_.index() > 0) {
+          __complete_();
+        } else {
+          __state_->__push_back_(this);
+        }
+      } else {
+        set_stopped((_Receiver&&) __rcvr_);
+      }
+    } catch(...) {
+      set_error((_Receiver&&) __rcvr_, current_exception());
+    }
+  }
+
+  template<sender _Sender>
+  inline void __future_state<_Sender>::__push_back_(__impl::__subscription* __subscription) {
+    unique_lock __lock{__mutex_};
+    if (__head_ == nullptr) {
+      __head_ = __subscription;
+    } else {
+      __tail_->__next_ = __subscription;
+    }
+    __tail_ = __subscription;
+    __subscription->__next_ = nullptr;
+    __cv_.notify_one();
+  }
+
+  template<sender _Sender>
+  inline __impl::__subscription* __future_state<_Sender>::__pop_front_() {
+    unique_lock __lock{__mutex_};
+    if (__head_ == nullptr) {
+      return nullptr;
+    }
+    auto* __subscription = __head_;
+    __head_ = __subscription->__next_;
+    if (__head_ == nullptr)
+      __tail_ = nullptr;
+    return __subscription;
+  }
+
+  template<sender _Sender>
+  class __future {
+    friend struct async_scope;
+
+  explicit __future(std::unique_ptr<__future_state<_Sender>> state) noexcept : state_(std::move(state)) 
+    {}
+
+  template <typename _Receiver>
+  friend __impl::__operation<__x<_Sender>, __x<decay_t<_Receiver>>>
+  tag_invoke(connect_t, __future&& __self, _Receiver&& __rcvr) {
+    return __impl::__operation<__x<_Sender>, __x<decay_t<_Receiver>>>{(_Receiver &&) __rcvr, std::move(__self.state_)};
+  }
+
+  template <__decays_to<__future> _Self, class _Env>
+    friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
+      -> completion_signatures_of_t<__member_t<_Self, _Sender>, _Env>;
+
+ private:
+   std::unique_ptr<__future_state<_Sender>> state_;
+  };
+
+  struct async_scope {
+  private:
+    template <typename Scheduler, typename Sender>
+    using _on_result_t =
+      decltype(on(__declval<Scheduler&&>(), __declval<Sender&&>()));
+
+    in_place_stop_source stopSource_;
+    // (opState_ & 1) is 1 until we've been stopped
+    // (opState_ >> 1) is the number of outstanding operations
+    std::atomic<std::size_t> opState_{1};
+    async_manual_reset_event evt_;
+
+    [[nodiscard]] auto await_and_sync() const noexcept {
+      return then(evt_.async_wait(), 
+      [this]() noexcept {
+        // make sure to synchronize with all the fetch_subs being done while
+        // operations complete
+        (void)opState_.load(std::memory_order_acquire);
+      });
+    }
+
+  public:
+    async_scope() noexcept = default;
+
+    ~async_scope() {
+      end_of_scope(); // enter stop state
+
+      [[maybe_unused]] auto state = opState_.load(std::memory_order_relaxed);
+
+      if (!is_stopping(state) || op_count(state) != 0) {
+        std::terminate();
+      }
+    }
+
+    template <typename _Sender>
+      //requires sender_to<_Sender, receiver<std::remove_cvref_t<_Sender>>>
+    void spawn(_Sender&& sender) {
+      // this could throw; if it does, there's nothing to clean up
+      auto opToStart = std::make_unique<std::optional<_operation_t<std::remove_cvref_t<_Sender>>>>();
+
+      // this could throw; if it does, the only clean-up we need is to
+      // deallocate the std::optional, which is handled by opToStart's
+      // destructor so we're good
+      opToStart->emplace(__conv{[&] {
+        return connect(
+            (_Sender&&) sender,
+            receiver<std::remove_cvref_t<_Sender>>{opToStart.get(), this});
+      }});
+
+      // At this point, the rest of the function is noexcept, but opToStart's
+      // destructor is no longer enough to properly clean up because it won't
+      // invoke destruct().  We need to ensure that we either call destruct()
+      // ourselves or complete the operation so *it* can call destruct().
+
+      if (try_record_start()) {
+        // start is noexcept so we can assume that the operation will complete
+        // after this, which means we can rely on its self-ownership to ensure
+        // that it is eventually deleted
+        std::execution::start(**opToStart.release());
+      }
+    }
+
+    template <typename _Sender>
+      requires sender_to<_Sender, future_receiver<std::remove_cvref_t<_Sender>>>
+    __future<std::remove_cvref_t<_Sender>> spawn_future(_Sender&& sender) { 
+      // this could throw; if it does, there's nothing to clean up
+      auto state = std::make_unique<__future_state<std::remove_cvref_t<_Sender>>>();
+
+      // this could throw; if it does, the only clean-up we need is to
+      // deallocate the std::optional, which is handled by opToStart's
+      // destructor so we're good
+      state->__op_.emplace(__conv{[&] {
+        return connect(
+            (_Sender&&) sender,
+            future_receiver<std::remove_cvref_t<_Sender>>{state.get(), this});
+      }});
+
+      // At this point, the rest of the function is noexcept, but opToStart's
+      // destructor is no longer enough to properly clean up because it won't
+      // invoke destruct().  We need to ensure that we either call destruct()
+      // ourselves or complete the operation so *it* can call destruct().
+
+      if (try_record_start()) {
+        // start is noexcept so we can assume that the operation will complete
+        // after this, which means we can rely on its self-ownership to ensure
+        // that it is eventually deleted
+        std::execution::start(*state->__op_);
+        return __future<std::remove_cvref_t<_Sender>>{std::move(state)}; 
+      }
+      // __future will complete with set_stopped
+      return __future<std::remove_cvref_t<_Sender>>{nullptr}; 
+    }
+
+    [[nodiscard]] auto empty() const noexcept {
+      return await_and_sync();
+    }
+
+    in_place_stop_source& get_stop_source() noexcept {
+      return stopSource_;
+    }
+
+    in_place_stop_token get_stop_token() const noexcept {
+      return stopSource_.get_token();
+    }
+
+    bool request_stop() noexcept {
+      end_of_scope();
+      return stopSource_.request_stop();
+    }
+
+  private:
+
+    static constexpr std::size_t stoppedBit{1};
+
+    static bool is_stopping(std::size_t state) noexcept {
+      return (state & stoppedBit) == 0;
+    }
+
+    static std::size_t op_count(std::size_t state) noexcept {
+      return state >> 1;
+    }
+
+    [[nodiscard]] bool try_record_start() noexcept {
+      auto opState = opState_.load(std::memory_order_relaxed);
+
+      do {
+        if (is_stopping(opState)) {
+          return false;
+        }
+
+        assert(opState + 2 > opState);
+      } while (!opState_.compare_exchange_weak(
+          opState,
+          opState + 2,
+          std::memory_order_relaxed));
+
+      evt_.reset();
+
+      return true;
+    }
+
+    friend void record_done(async_scope* scope) noexcept {
+      auto oldState = scope->opState_.fetch_sub(2, std::memory_order_release);
+
+      if (op_count(oldState) == 1) {
+        // the last op to finish
+        scope->evt_.set();
+      }
+    }
+
+    void end_of_scope() noexcept {
+      // stop adding work
+      auto oldState = opState_.fetch_and(~stoppedBit, std::memory_order_release);
+
+      if (op_count(oldState) == 0) {
+        // there are no outstanding operations to wait for
+        evt_.set();
+      }
+    }
+  };
+
+  } // namespace __scope
+
+  using __scope::async_scope;
 
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.schedule_from]

--- a/include/stop_token.hpp
+++ b/include/stop_token.hpp
@@ -126,14 +126,14 @@ namespace std {
     template <class>
       friend class in_place_stop_callback;
 
-    uint8_t __lock_() noexcept;
+    uint8_t __lock_() const noexcept;
     void __unlock_(uint8_t) const noexcept;
 
     bool __try_lock_unless_stop_requested_(bool) const noexcept;
 
     bool __try_add_callback_(__detail::__in_place_stop_callback_base*) const noexcept;
 
-    void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    void __remove_callback_(__detail::__in_place_stop_callback_base*) const noexcept;
 
     static constexpr uint8_t __stop_requested_flag_ = 1;
     static constexpr uint8_t __locked_flag_ = 2;
@@ -269,7 +269,7 @@ namespace std {
     return false;
   }
 
-  inline uint8_t in_place_stop_source::__lock_() noexcept {
+  inline uint8_t in_place_stop_source::__lock_() const noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
     do {
@@ -277,7 +277,7 @@ namespace std {
         __spin.__wait();
         __old_state = __state_.load(memory_order_relaxed);
       }
-    } while (!__state_.compare_exchange_weak(
+    } while (!const_cast<atomic<uint8_t>&>(__state_).compare_exchange_weak(
         __old_state,
         __old_state | __locked_flag_,
         memory_order_acquire,
@@ -337,7 +337,7 @@ namespace std {
   }
 
   inline void in_place_stop_source::__remove_callback_(
-      __detail::__in_place_stop_callback_base* __callbk) noexcept {
+      __detail::__in_place_stop_callback_base* __callbk) const noexcept {
   auto __old_state = __lock_();
 
     if (__callbk->__prev_ptr_ != nullptr) {

--- a/include/stop_token.hpp
+++ b/include/stop_token.hpp
@@ -47,14 +47,14 @@ namespace std {
 
      protected:
       using __execute_fn_t = void(__in_place_stop_callback_base*) noexcept;
-      explicit __in_place_stop_callback_base(in_place_stop_source* __source, __execute_fn_t* __execute) noexcept
+      explicit __in_place_stop_callback_base(const in_place_stop_source* __source, __execute_fn_t* __execute) noexcept
         : __source_(__source), __execute_(__execute) {}
 
       void __register_callback_() noexcept;
 
       friend in_place_stop_source;
 
-      in_place_stop_source* __source_;
+      const in_place_stop_source* __source_;
       __execute_fn_t* __execute_;
       __in_place_stop_callback_base* __next_ = nullptr;
       __in_place_stop_callback_base** __prev_ptr_ = nullptr;
@@ -113,7 +113,7 @@ namespace std {
     ~in_place_stop_source();
     in_place_stop_source(in_place_stop_source&&) = delete;
 
-    in_place_stop_token get_token() noexcept;
+    in_place_stop_token get_token() const noexcept;
 
     bool request_stop() noexcept;
     bool stop_requested() const noexcept {
@@ -127,11 +127,11 @@ namespace std {
       friend class in_place_stop_callback;
 
     uint8_t __lock_() noexcept;
-    void __unlock_(uint8_t) noexcept;
+    void __unlock_(uint8_t) const noexcept;
 
-    bool __try_lock_unless_stop_requested_(bool) noexcept;
+    bool __try_lock_unless_stop_requested_(bool) const noexcept;
 
-    bool __try_add_callback_(__detail::__in_place_stop_callback_base*) noexcept;
+    bool __try_add_callback_(__detail::__in_place_stop_callback_base*) const noexcept;
 
     void __remove_callback_(__detail::__in_place_stop_callback_base*) noexcept;
 
@@ -182,13 +182,13 @@ namespace std {
     template <class>
       friend class in_place_stop_callback;
 
-    explicit in_place_stop_token(in_place_stop_source* __source) noexcept
+    explicit in_place_stop_token(const in_place_stop_source* __source) noexcept
       : __source_(__source) {}
 
-    in_place_stop_source* __source_;
+    const in_place_stop_source* __source_;
   };
 
-  inline in_place_stop_token in_place_stop_source::get_token() noexcept {
+  inline in_place_stop_token in_place_stop_source::get_token() const noexcept {
     return in_place_stop_token{this};
   }
 
@@ -286,12 +286,12 @@ namespace std {
     return __old_state;
   }
 
-  inline void in_place_stop_source::__unlock_(uint8_t __old_state) noexcept {
-    (void)__state_.store(__old_state, memory_order_release);
+  inline void in_place_stop_source::__unlock_(uint8_t __old_state) const noexcept {
+    (void)const_cast<atomic<uint8_t>&>(__state_).store(__old_state, memory_order_release);
   }
 
   inline bool in_place_stop_source::__try_lock_unless_stop_requested_(
-      bool __set_stop_requested) noexcept {
+      bool __set_stop_requested) const noexcept {
     __detail::__spin_wait __spin;
     auto __old_state = __state_.load(memory_order_relaxed);
     do {
@@ -306,7 +306,7 @@ namespace std {
           __old_state = __state_.load(memory_order_relaxed);
         }
       }
-    } while (!__state_.compare_exchange_weak(
+    } while (!const_cast<atomic<uint8_t>&>(__state_).compare_exchange_weak(
         __old_state,
         __set_stop_requested ? (__locked_flag_ | __stop_requested_flag_) : __locked_flag_,
         memory_order_acq_rel,
@@ -317,17 +317,19 @@ namespace std {
   }
 
   inline bool in_place_stop_source::__try_add_callback_(
-      __detail::__in_place_stop_callback_base* __callbk) noexcept {
+      __detail::__in_place_stop_callback_base* __callbk) const noexcept {
     if (!__try_lock_unless_stop_requested_(false)) {
       return false;
     }
 
-    __callbk->__next_ = __callbacks_;
-    __callbk->__prev_ptr_ = &__callbacks_;
-    if (__callbacks_ != nullptr) {
-      __callbacks_->__prev_ptr_ = &__callbk->__next_;
+    auto& callbacks = *const_cast<__detail::__in_place_stop_callback_base**>(&this->__callbacks_);
+
+    __callbk->__next_ = callbacks;
+    __callbk->__prev_ptr_ = &callbacks;
+    if (callbacks != nullptr) {
+      callbacks->__prev_ptr_ = &__callbk->__next_;
     }
-    __callbacks_ = __callbk;
+    callbacks = __callbk;
 
     __unlock_(0);
 


### PR DESCRIPTION
This PR builds on the work in execution.hpp to support `async_scope` and adds support for spawning multiple threads via a `spawn_on` member function.  I made the following changes to execution.hpp:
  - I copied a few snippets of code out of libunifex for `spawn_on`, `just_from`, and `complete`.  
  - I rearranged some blocks of code so the various dependencies among `async_scope`, `on`, and `just_from` would work properly.
  - `async_scope::complete` from libunifex used `sequence`, which didn't seem to be available in execution.hpp, so I simply have the two calls that were in the sequence execute in order.
  - I added a notice to the header of execution.hpp that some bits of code had been derived from libunifex.
  - Some of the concepts seemed differently-named between libunifex and wg21_p2300_std_execution.  I didn't attempt mapping the former to the latter.  I just commented out the requires clauses for the moment.

`spawn_on` seems to work well, at least in the example I have at https://github.com/lums658/sieve_exec_comparison (currently in the async_scope branch but will be moved to main).