### PR TITLE
GCC quirks

### DIFF
--- a/include/__utility.hpp
+++ b/include/__utility.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 
 #ifdef _P2300_ASSERT
-#error Hammer says, ya can't touch this
+#error "Hammer says, ya can't touch this"
 #endif
 
 #define _P2300_ASSERT(_X) \


### PR DESCRIPTION
These changes allow the `fixfuture` branch ("fixes for async_scope", [PR #606](https://github.com/brycelelbach/wg21_p2300_std_execution/pull/606)) to compile on GCC version 12.2.0 on MSYS2, and versions 11.2.0 and 12.0.1 on Ubuntu. No warnings, all tests pass.
